### PR TITLE
Selecting only type and payload for attachments

### DIFF
--- a/lib/messenger/parameters/message.rb
+++ b/lib/messenger/parameters/message.rb
@@ -13,7 +13,7 @@ module Messenger
       end
 
       def build_attachments(attachments)
-        attachments.map { |attachment| Attachment.new(attachment.symbolize_keys) }
+        attachments.map { |attachment| Attachment.new(attachment.symbolize_keys.slice(:type, :payload)) }
       end
     end
   end


### PR DESCRIPTION
With ruby 2.2.1 this was breaking as class was not accepting more arguments in initializer. 

Facebook sends title & url sometimes in attachment which was breaking call to initialization of attachment.