### PR TITLE
Add sticker id for initialize

### DIFF
--- a/lib/messenger/parameters/message.rb
+++ b/lib/messenger/parameters/message.rb
@@ -3,11 +3,12 @@ module Messenger
     class Message
       include Callback
 
-      attr_accessor :mid, :seq, :text, :attachments
+      attr_accessor :mid, :seq, :sticker_id, :text, :attachments
 
-      def initialize(mid:, seq:, text: nil, attachments: nil)
+      def initialize(mid:, seq:, sticker_id: nil, text: nil, attachments: nil)
         @mid         = mid
         @seq         = seq
+        @sticker_id  = sticker_id if sticker_id.present?
         @text        = text if text.present?
         @attachments = build_attachments(attachments) if attachments.present?
       end


### PR DESCRIPTION
It'll show "ArgumentError (unknown keyword: sticker_id)" when a client sent a sticker to bot.
I add sticker_id in initialize for fixing the issue.