### PR TITLE
Allow additional Message attributes

### DIFF
--- a/lib/messenger/parameters/message.rb
+++ b/lib/messenger/parameters/message.rb
@@ -3,14 +3,17 @@ module Messenger
     class Message
       include Callback
 
-      attr_accessor :mid, :seq, :sticker_id, :text, :attachments
+      attr_accessor :mid, :seq, :sticker_id, :text, :attachments, :is_echo, :app_id, :metadata
 
-      def initialize(mid:, seq:, sticker_id: nil, text: nil, attachments: nil)
+      def initialize(mid:, seq:, sticker_id: nil, text: nil, attachments: nil, is_echo: nil, app_id: nil, metadata: nil)
         @mid         = mid
         @seq         = seq
         @sticker_id  = sticker_id if sticker_id.present?
         @text        = text if text.present?
         @attachments = build_attachments(attachments) if attachments.present?
+        @is_echo     = is_echo
+        @app_id      = app_id
+        @metadata    = metadata
       end
 
       def build_attachments(attachments)

--- a/messenger-ruby.gemspec
+++ b/messenger-ruby.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'webmock'
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rails"
+  spec.add_development_dependency "rails", "~> 4.2.6"
   spec.add_development_dependency "codeclimate-test-reporter"
 end

--- a/spec/messenger/parameters/message_spec.rb
+++ b/spec/messenger/parameters/message_spec.rb
@@ -63,6 +63,9 @@ module Messenger
             described_class.new(
               mid: "abc",
               seq: 10,
+              is_echo: true,
+              app_id: "123",
+              metadata: "007",
               attachments: [
                 { type: 'image', payload: { 'url' => 'abc' } },
                 { type: 'audio', payload: { 'url' => 'xyz' } },


### PR DESCRIPTION
Add `is_echo`, `app_id` and `metadata` args to `Message` object according to Facebook API changes. 

Related issue: #21 