### PR TITLE
Use transform_keys instead of deprecated symbolize_keys

### DIFF
--- a/lib/messenger/parameters/entry.rb
+++ b/lib/messenger/parameters/entry.rb
@@ -10,7 +10,7 @@ module Messenger
       end
 
       def build_messagings(messagings)
-        messagings.map { |messaging| Messaging.new(messaging.symbolize_keys) }
+        messagings.map { |messaging| Messaging.new(messaging.transform_keys(&:to_sym)) }
       end
     end
   end

--- a/lib/messenger/parameters/message.rb
+++ b/lib/messenger/parameters/message.rb
@@ -17,7 +17,7 @@ module Messenger
       end
 
       def build_attachments(attachments)
-        attachments.map { |attachment| Attachment.new(attachment.symbolize_keys.slice(:type, :payload)) }
+        attachments.map { |attachment| Attachment.new(attachment.transform_keys(&:to_sym).slice(:type, :payload)) }
       end
     end
   end

--- a/lib/messenger/parameters/messaging.rb
+++ b/lib/messenger/parameters/messaging.rb
@@ -11,7 +11,7 @@ module Messenger
 
       def set_callback(callbacks)
         type = callbacks.select { |_, v| v.present? }.keys.first
-        @callback = constant(type).new(callbacks[type].symbolize_keys)
+        @callback = constant(type).new(callbacks[type].transform_keys(&:to_sym))
       end
 
       private

--- a/lib/messenger/params.rb
+++ b/lib/messenger/params.rb
@@ -17,7 +17,7 @@ module Messenger
     private
 
     def build_entries
-      params['entry'].map { |entry| Parameters::Entry.new(entry.symbolize_keys) }
+      params['entry'].map { |entry| Parameters::Entry.new(entry.transform_keys(&:to_sym)) }
     end
   end
 end


### PR DESCRIPTION
As `symbolize_keys` method is deprecated and will be removed in Rails 5.1, use `transform_keys` instead to provide compatibility. `transform_keys` is present since Rails 4.0.

Fixes #15 
