### PR TITLE
Replace render with head in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Create `messenger_controller.rb` in your controllers directory - controller has 
 class MessengerController < Messenger::MessengerController
   def webhook
     #logic here
-    render nothing: true, status: 200
+    head :ok 
   end
 end
 ```
@@ -293,7 +293,7 @@ if fb_params.first_entry.callback.message?
 end
 
 #make sure to send 200 at the end
-render nothing: true, status: 200
+head :ok
 ```
 
 #### Image


### PR DESCRIPTION
`render nothing: true` was deprecated in Rails 5 and will be removed in 5.1:

> Remove deprecated support to :nothing in render.
>
> Rafael Mendonça França

https://github.com/rails/rails/blob/master/actionpack/CHANGELOG.md