### PR TITLE
Fix typo in receipt item accessor

### DIFF
--- a/lib/messenger/components/elements/receipt/item.rb
+++ b/lib/messenger/components/elements/receipt/item.rb
@@ -5,7 +5,7 @@ module Messenger
     class Item
       include Components::Element
 
-      attr_accessor :title, :subtitle, :quantity, :price, :urrency, :image_url
+      attr_accessor :title, :subtitle, :quantity, :price, :currency, :image_url
 
       def initialize(title:, subtitle: nil, quantity: nil, price: nil, currency: nil, image_url: nil)
         @title     = title


### PR DESCRIPTION
Fixes a typo in one of the `currency` parameter passed to `attr_accessor` in the receipt item. It was missing a "c".