### PR TITLE
Fix unpermitted location params

### DIFF
--- a/app/controllers/messenger/messenger_controller.rb
+++ b/app/controllers/messenger/messenger_controller.rb
@@ -56,8 +56,10 @@ module Messenger
                                             { attachments: [
                                               :type,
                                               :url,
-                                              { coordinates: :lat },
-                                              { coordinates: :long }
+                                              :title,
+                                              payload: { coordinates: [
+                                                :lat, :long
+                                              ] }
                                             ] },
                                             { quick_reply: :payload },
                                             :is_echo,


### PR DESCRIPTION
The location callback has two extra parameters, `title` and `payload`. The `payload` has `coordinates`, which in turn has `lan` and `long`. The current `fb_params` method didn't permit those parameters.