### PR TITLE
Added quick_reply to message attr_accessor

### DIFF
--- a/lib/messenger/parameters/message.rb
+++ b/lib/messenger/parameters/message.rb
@@ -3,7 +3,7 @@ module Messenger
     class Message
       include Callback
 
-      attr_accessor :mid, :seq, :sticker_id, :text, :attachments, :is_echo, :app_id, :metadata
+      attr_accessor :mid, :seq, :sticker_id, :text, :attachments, :quick_reply, :is_echo, :app_id, :metadata
 
       def initialize(mid:, seq:, sticker_id: nil, text: nil, attachments: nil, quick_reply: nil, is_echo: nil, app_id: nil, metadata: nil)
         @mid         = mid


### PR DESCRIPTION
The message was parsing and storing the `quick_reply` but it wasn't accessible.