### PR TITLE
Fixed issue #47 on original Repo

### DIFF
--- a/app/controllers/messenger/messenger_controller.rb
+++ b/app/controllers/messenger/messenger_controller.rb
@@ -56,6 +56,10 @@ module Messenger
                                             { attachments: [
                                               :type,
                                               :url,
+                                              {payload: [
+                                                :url,
+                                                :sticker_id,
+                                                ] },
                                               { coordinates: :lat },
                                               { coordinates: :long }
                                             ] },


### PR DESCRIPTION
I had created this Issue.
When My app receives a sticker to an Image it throws Argument Error with message unknown keyword :payload in messenger_controller.rb line number 5. How to add keyword payload. I think it should be permitted in safe_params in gems messenger_controller.rb. I forked and tested with adding keyword but it prevents server with starting shows error. Please help