### PR TITLE
Fix library on Rails 5.2.1

### DIFF
--- a/lib/messenger/params.rb
+++ b/lib/messenger/params.rb
@@ -19,7 +19,7 @@ module Messenger
     private
 
     def build_entries
-      params['entry'].map { |entry| Parameters::Entry.new(entry.to_h.transform_keys(&:to_sym)) }
+      params['entry'].map { |entry| Parameters::Entry.new(entry.to_hash.transform_keys(&:to_sym)) }
     end
   end
 end


### PR DESCRIPTION
This PR fixes following error on Rails 5.2.1:

```
wrong number of arguments (given 1, expected 0; required keywords: id,
time) excluded from capture: DSN not set

ArgumentError (wrong number of arguments (given 1, expected 0; required
keywords: id, time)):

messenger-ruby (1.2.1) lib/messenger/parameters/entry.rb:6:in
`initialize'
messenger-ruby (1.2.1) lib/messenger/params.rb:23:in `new'
messenger-ruby (1.2.1) lib/messenger/params.rb:23:in `block in
build_entries'
messenger-ruby (1.2.1) lib/messenger/params.rb:23:in `map'
messenger-ruby (1.2.1) lib/messenger/params.rb:23:in `build_entries'
messenger-ruby (1.2.1) lib/messenger/params.rb:10:in `entries'
app/controllers/messenger_controller.rb:9:in `webhook'
```

This used to work because `HashWithIndifferentAccess#transform_keys`
returned `Hash` but now it returns `HashWithIndifferentAccess`.

Specifically following commit has altered this behaviour:

https://github.com/rails/rails/commit/de9e3238a008f8f20c5beedefb8787b6e51359d0#diff-9f4b3d7342097a6f22290f147a09b77b